### PR TITLE
Changed shell lines in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ Usually, ruby-build is run via rbenv, so the instructions below use `rbenv` for 
 ```shell
 git clone git://github.com/veracross/ruby-build-ree-1.8.7-2012.02-glibc-2.18.git
 cd ruby-build-ree-1.8.7-2012.02-glibc-2.18
-rbenv install ./ruby-build-ree-1.8.7-2012.02
+rbenv install ./ree-1.8.7-2012.02
 ```
 
 ## Why


### PR DESCRIPTION
Recipe file in repo was called ree-1.8.7-2012.02 instead of ruby-build-ree-1.8.7-2012.02 so sample shell code fails when copyed and pasted. Updated file name readme.md.

Sorry to bother I was bored enough while compiling REE to send this PR :) you can safely drop it.

It was only a question of file names in sampe doc. 